### PR TITLE
Form expansion

### DIFF
--- a/client/src/pages/EditBot.js
+++ b/client/src/pages/EditBot.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, TextField, Button, FormControl, InputLabel, Select, Menu, MenuItem, Divider, Paper } from '@material-ui/core';
+import { Box, TextField, Button, FormControl, InputLabel, Select, MenuItem, Divider, Paper, RadioGroup, Radio, FormControlLabel } from '@material-ui/core';
 import { loadBot } from '../store/bots'
 import { makeStyles } from '@material-ui/core';
 
@@ -53,7 +53,7 @@ const useStyle = makeStyles((theme) => ({
 function EditBot({bot, botId, user}) {
 
     const BLANK_RESPONSE = {type: "", details: { string: "" }}
-    const BLANK_RULE = { prefix: "", content: { trigger: {type: "", usesPrefix: true, details: { string: "" }}, response: [BLANK_RESPONSE] } };
+    const BLANK_RULE = { prefix: "", content: { trigger: {type: "", usesPrefix: true, details: { string: "", includesOrBeginsWith: "begins with" }}, response: [BLANK_RESPONSE] } };
 
     const [botName, setBotName] = useState("");
     const [rules, setRules] = useState([]);
@@ -120,11 +120,20 @@ function EditBot({bot, botId, user}) {
                         </Grid>
                         <Grid item xs className={classes.grid}>
                             {rules[i].content.trigger.type === "message"
-                                ? <><TextField
+                                ? <>
+                                <FormControl>
+                                <RadioGroup value={rules[i].content.trigger.details.includesOrBeginsWith}
+                                            onChange={e => setRule(i, {...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, includesOrBeginsWith: e.target.value } } }})}
+                                >
+                                    <FormControlLabel value="includes" control={<Radio />} label="Includes" />
+                                    <FormControlLabel value="begins with" control={<Radio />} label="Begins with" />
+                                </RadioGroup>
+                                </FormControl>
+                                <TextField
                                         variant="outlined"
                                         fullWidth
                                         value={rules[i].content.trigger.details.string}
-                                        label="message string"
+                                        label={`message ${rules[i].content.trigger.details.includesOrBeginsWith} string...`}
                                         onChange={e => setRule(i, { ...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, string: e.target.value } } } })} /></>
                                 : <></>}
                         </Grid>

--- a/client/src/pages/EditBot.js
+++ b/client/src/pages/EditBot.js
@@ -169,16 +169,17 @@ function EditBot({bot, botId, user}) {
                             label="Select a Response"
                         >
                             <MenuItem value="message">Message</MenuItem>
+                            <MenuItem value="emoji">Emoji react to triggering message</MenuItem>
                         </Select>
                     </FormControl>
                 </Grid>
                 <Grid item xs className={classes.grid}>
-                    {rules[ruleIndex].content.response[responseIndex].type === "message"
+                    {["message", "emoji"].includes(rules[ruleIndex].content.response[responseIndex].type)
                         ? <TextField
                         variant="outlined"
                         fullWidth
                         value={rules[ruleIndex].content.response[responseIndex].details.string}
-                        label="response message"
+                        label={rules[ruleIndex].content.response[responseIndex].type === "message" ? "message string" : "emoji name"}
                         onChange={e => setRule(ruleIndex, { ...rules[ruleIndex], content: { ...rules[ruleIndex].content, response: [{ ...rules[ruleIndex].content.response[responseIndex], details: { ...rules[ruleIndex].content.response[responseIndex].details, string: e.target.value } }] } })} />
                         : <></>}
                 </Grid>

--- a/client/src/pages/EditBot.js
+++ b/client/src/pages/EditBot.js
@@ -120,12 +120,12 @@ function EditBot({bot, botId, user}) {
                         </Grid>
                         <Grid item xs className={classes.grid}>
                             {rules[i].content.trigger.type === "message"
-                                ? <TextField
+                                ? <><TextField
                                         variant="outlined"
                                         fullWidth
                                         value={rules[i].content.trigger.details.string}
-                                        label="Message"
-                                        onChange={e => setRule(i, { ...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, string: e.target.value } } } })} />
+                                        label="message string"
+                                        onChange={e => setRule(i, { ...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, string: e.target.value } } } })} /></>
                                 : <></>}
                         </Grid>
                     </Grid>
@@ -169,7 +169,7 @@ function EditBot({bot, botId, user}) {
                         variant="outlined"
                         fullWidth
                         value={rules[ruleIndex].content.response[responseIndex].details.string}
-                        label="Response message: "
+                        label="response message"
                         onChange={e => setRule(ruleIndex, { ...rules[ruleIndex], content: { ...rules[ruleIndex].content, response: [{ ...rules[ruleIndex].content.response[responseIndex], details: { ...rules[ruleIndex].content.response[responseIndex].details, string: e.target.value } }] } })} />
                         : <></>}
                 </Grid>


### PR DESCRIPTION
This adds an `includesOrBeginsWith` field to the `details` section of every rule contents. This new field has two possible values: `"begins with"` and `"includes"`.

(Nothing will break when accessing legacy seed data, apart from one field label having the word "undefined" in it, but this is not behavior that a real user will encounter and it is easily rectifiable by just selecting one of the options in the GUI.)

Also adds `emoji` as a possible response type; if the type is `emoji` the "string" field in the response's `details` will hold the name of the emoji to be added to the trigger message.