### PR TITLE
Form expansion

### DIFF
--- a/client/src/pages/EditBot.js
+++ b/client/src/pages/EditBot.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, TextField, Button, FormControl, InputLabel, Select, MenuItem, Divider, Paper, RadioGroup, Radio, FormControlLabel } from '@material-ui/core';
+import { Box, TextField, Button, FormControl, InputLabel, Select, MenuItem, Divider, Paper, RadioGroup, Radio, FormControlLabel, Checkbox } from '@material-ui/core';
 import { loadBot } from '../store/bots'
 import { loadUser } from '../store/auth';
 import { makeStyles } from '@material-ui/core';
@@ -64,9 +64,6 @@ function EditBot({bot, botId, user}) {
     const classes = useStyle();
 
     useEffect(() => {
-        // console.log(bot);
-        // console.log(bot.rules);
-        // console.log(rules);
         if (rules.length === 0){
             setRules(bot.rules);
         }
@@ -124,20 +121,23 @@ function EditBot({bot, botId, user}) {
                         <Grid item xs className={classes.grid}>
                             {rules[i].content.trigger.type === "message"
                                 ? <>
-                                <FormControl>
-                                <RadioGroup value={rules[i].content.trigger.details.includesOrBeginsWith}
-                                            onChange={e => setRule(i, {...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, includesOrBeginsWith: e.target.value } } }})}
-                                >
-                                    <FormControlLabel value="includes" control={<Radio />} label="Includes" />
-                                    <FormControlLabel value="begins with" control={<Radio />} label="Begins with" />
-                                </RadioGroup>
-                                </FormControl>
                                 <TextField
                                         variant="outlined"
                                         fullWidth
                                         value={rules[i].content.trigger.details.string}
                                         label={`message ${rules[i].content.trigger.details.includesOrBeginsWith} string...`}
-                                        onChange={e => setRule(i, { ...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, string: e.target.value } } } })} /></>
+                                        onChange={e => setRule(i, { ...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, string: e.target.value } } } })} />
+                                  <FormControl>
+                                        <RadioGroup value={rules[i].content.trigger.details.includesOrBeginsWith}
+                                            onChange={e => setRule(i, {...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, details: { ...rules[i].content.trigger.details, includesOrBeginsWith: e.target.value } } }})}
+                                >
+                                    <FormControlLabel value="includes" control={<Radio />} label="Includes" />
+                                    <FormControlLabel value="begins with" control={<Radio />} label="Begins with" />
+                                </RadioGroup>
+                                <FormControlLabel label="Uses prefix" control={<Checkbox checked={rules[i].content.trigger.usesPrefix}
+                                           onChange={e => setRule(i, {...rules[i], content: { ...rules[i].content, trigger: { ...rules[i].content.trigger, usesPrefix: e.target.checked } } })} />}>Uses prefix</FormControlLabel>
+                                </FormControl>
+                                  </>
                                 : <></>}
                         </Grid>
                     </Grid>


### PR DESCRIPTION
This adds checkboxes to each message trigger text field which allow the user to set the "usesPrefix" option (which we have already built in) to true or false. Together with the radio buttons, this starts to take up quite a bit of vertical space, but I'm not sure yet the best way to handle that. Saving still works, etc.