### PR TITLE
Fix warnings

### DIFF
--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -129,7 +129,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
               .filter(bot => bot.is_draft === false)
               .map(bot => {
                 return (
-                  <>
+                  <div key={bot.id}>
                     <CardActionArea key={bot.id}>
                       <Link key={bot.id} to={`/bots/${bot.id}`} style={{ color: 'inherit' }}>
                         <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
@@ -156,7 +156,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
                       </div>
                     </div>
                     <Divider />
-                  </>
+                  </div>
                 );
               })}
           </div>
@@ -210,7 +210,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
               .filter(bot => bot.user_id === user.id)
               .map(bot => {
                 return (
-                  <>
+                  <div key={bot.id}>
                     <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
                       <Typography variant='h5' style={{ fontWeight: 'bold' }}>
                         {bot.name}
@@ -228,7 +228,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
                       </div>
                     </div>
                     <Divider />
-                  </>
+                  </div>
                 );
               })}
           </div>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -51,7 +51,7 @@ function a11yProps(index) {
 
 const useStyles = makeStyles(theme => ({
   container: {
-    'margin-left': '25%',
+    marginLeft: '25%',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-start',
@@ -121,8 +121,8 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
           index={0}
           style={{
             backgroundColor: '#282828',
-            'border-bottom-left-radius': '5px',
-            'border-bottom-right-radius': '5px',
+            borderBottomLeftRadius: '5px',
+            borderBottomRightRadius: '5px',
           }}>
           <div>
             {bots
@@ -166,8 +166,8 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
           index={1}
           style={{
             backgroundColor: '#282828',
-            'border-bottom-left-radius': '5px',
-            'border-bottom-right-radius': '5px',
+            borderBottomLeftRadius: '5px',
+            borderBottomRightRadius: '5px',
           }}>
           <div>
             {bots

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -202,8 +202,8 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
           index={2}
           style={{
             backgroundColor: '#282828',
-            'border-bottom-left-radius': '5px',
-            'border-bottom-right-radius': '5px',
+            borderBottomLeftRadius: '5px',
+            borderBottomRightRadius: '5px',
           }}>
           <div>
             {bots

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -306,7 +306,8 @@ export function Dashboard({ user, token, bots, loadBotDispatch, loadBotsDispatch
 
 export default function DashboardContainer() {
   const dispatch = useDispatch();
-  const user = useSelector(state => state.auth.user);
+  //const user = useSelector(state => state.auth.user);
+  const user = JSON.parse(window.localStorage.getItem('auth/USER'));
   const token = useSelector(state => state.auth.token);
   const bots = useSelector(state => state.bots.list);
   const loadBotDispatch = botId => dispatch(loadBot(botId));

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -109,7 +109,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
       <div className={classes.root}>
         <AppBar
           position='static'
-          style={{ backgroundColor: '#282828', 'border-top-left-radius': '5px', 'border-top-right-radius': '5px' }}>
+          style={{ backgroundColor: '#282828', borderTopLeftRadius: '5px', borderTopRightRadius: '5px' }}>
           <Tabs value={value} onChange={handleChange} aria-label='simple tabs example'>
             <Tab label='Bots' {...a11yProps(0)} />
             <Tab label='Drafts' {...a11yProps(1)} />

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -149,7 +149,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
                           <Link to={`edit-bot/${bot.id}`} style={{ color: 'inherit' }} title='Edit Bot'>
                             <i onClick={handleEdit} id={`bot-${bot.id}`} className='fas fa-edit'></i>
                           </Link>
-                          <Link style={{ color: 'inherit' }} title='Delete Bot'>
+                          <Link style={{ color: 'inherit' }} to={``} title='Delete Bot'>
                             <i onClick={handleDelete} id={`bot-${bot.id}`} className='fas fa-trash'></i>
                           </Link>
                         </CardActionArea>
@@ -186,7 +186,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
                         <Link to={`edit-bot/${bot.id}`} style={{ color: 'inherit' }} title='Edit Bot'>
                           <i onClick={handleEdit} id={`bot-${bot.id}`} className='fas fa-edit'></i>
                         </Link>
-                        <Link style={{ color: 'inherit' }} title='Delete Bot'>
+                        <Link style={{ color: 'inherit' }} title='Delete Bot' to={``}>
                           <i onClick={handleDelete} id={`bot-${bot.id}`} className='fas fa-trash'></i>
                         </Link>
                       </div>
@@ -222,7 +222,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
                         <Link to={''} style={{ color: 'inherit' }} title='Download Bot'>
                           <i onClick={handleDownload} id={`bot-${bot.id}`} className='fas fa-download'></i>
                         </Link>
-                        <Link style={{ color: 'inherit' }} title='Clone Bot'>
+                        <Link to={``} style={{ color: 'inherit' }} title='Clone Bot'>
                           <i onClick={handleClone} id={`bot-${bot.id}`} className='fas fa-clone'></i>
                         </Link>
                       </div>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -130,7 +130,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
               .map(bot => {
                 return (
                   <>
-                    <CardActionArea>
+                    <CardActionArea key={bot.id}>
                       <Link key={bot.id} to={`/bots/${bot.id}`} style={{ color: 'inherit' }}>
                         <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
                           <Typography variant='h5' style={{ fontWeight: 'bold' }}>
@@ -174,7 +174,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
               .filter(bot => bot.is_draft === true)
               .map(bot => {
                 return (
-                  <>
+                  <div key={bot.id}>
                     <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
                       <Typography variant='h5' style={{ fontWeight: 'bold' }}>
                         {bot.name}
@@ -192,7 +192,7 @@ export function Dashboard({ user, token, bots, loadBotsDispatch, deleteBotDispat
                       </div>
                     </div>
                     <Divider />
-                  </>
+                  </div>
                 );
               })}
           </div>

--- a/client/src/pages/Explore.js
+++ b/client/src/pages/Explore.js
@@ -51,9 +51,9 @@ const useStyle = makeStyles(theme => ({
 const ListItem = ({ id, name, description, username }) => {
   const classes = useStyle();
   return (
-    <Grid item xs={12} className={classes.bot}>
+    <Grid key={id} item xs={12} className={classes.bot}>
       <CardActionArea className={classes.action}>
-        <Link key={id} to={`/bots/${id}`} style={{ color: 'inherit' }}>
+        <Link to={`/bots/${id}`} style={{ color: 'inherit' }}>
           <Typography variant='h5' component='h2' style={{ fontWeight: 'bold' }}>
             {name}
           </Typography>
@@ -65,10 +65,10 @@ const ListItem = ({ id, name, description, username }) => {
         </Link>
       </CardActionArea>
       <div className={classes.content}>
-        <Link key={id} to={``} style={{ color: 'inherit' }} title='Download Bot'>
+        <Link to={``} style={{ color: 'inherit' }} title='Download Bot'>
           <i className='fas fa-download fa-lg'></i>
         </Link>
-        <Link key={id} to={``} style={{ color: 'inherit' }} title='Clone Bot'>
+        <Link to={``} style={{ color: 'inherit' }} title='Clone Bot'>
           <i className='fas fa-clone fa-lg'></i>
         </Link>
       </div>
@@ -130,6 +130,7 @@ export function Explore({ bots }) {
               {botsMatchingQuery.map(bot => (
                 <ListItem
                   name={bot.name}
+                  key={bot.id}
                   id={bot.id}
                   description={bot.description}
                   username={bot.owner.username}

--- a/client/src/pages/Explore.js
+++ b/client/src/pages/Explore.js
@@ -117,7 +117,7 @@ export function Explore({ bots }) {
                 onChange={handleSearch}
                 size='medium'
                 variant='filled'
-                fullWidth='true'
+                fullWidth
                 InputProps={{
                   endAdornment: (
                     <InputAdornment position='end'>

--- a/client/src/pages/LoginPage.js
+++ b/client/src/pages/LoginPage.js
@@ -130,7 +130,7 @@ export const LoginPage = ({ user, loginDispatcher, loadUserDispatcher }) => {
                     variant='contained'
                     style={{ backgroundColor: '#7289da' }}
                     href='https://discord.com/oauth2/authorize?client_id=771154573795655680&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fredirect&response_type=code&scope=identify%20email%20connections%20guilds'>
-                    <span style={{ 'margin-right': '5px' }}>
+                    <span style={{ marginRight: '5px' }}>
                       <i className='fab fa-discord' />
                     </span>
                     Log in with Discord


### PR DESCRIPTION
Clears out a bunch of red warnings that were being displayed in the console on the Dashboard and Explore pages. Major outstanding warning type still left is an issue with the use of the Typography component on the Dashboard, which may meaningfully alter styling when fixed, so it's not included here.