### PR TITLE
Fix create button so it always goes to a blank form

### DIFF
--- a/app/api/bots.py
+++ b/app/api/bots.py
@@ -91,6 +91,14 @@ def get_all_published_bots():
     data = [bot.to_dict() for bot in bots]
     return jsonify(data=data)
 
+@bot_routes.route('/complete')
+def get_all_bots():
+    bots = Bot.query \
+              .options(joinedload(Bot.owner)) \
+              .all()
+    data = [bot.to_dict() for bot in bots]
+    return jsonify(data=data)
+
 # Grabbing the info of a particular published bots, navigated to from the explore page - Ammar
 
 

--- a/client/src/constants/index.js
+++ b/client/src/constants/index.js
@@ -12,3 +12,5 @@ export const TOKEN = 'auth/TOKEN';
 export const USER = 'auth/USER';
 
 export const SET_BOT = 'bots/GET_BOT';
+
+export const SET_COMPLETE = 'bots/SET_COMPLETE';

--- a/client/src/pages/CreateBot.js
+++ b/client/src/pages/CreateBot.js
@@ -1,22 +1,22 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { loadAllBots } from '../store/bots';
+import { loadCompleteBots } from '../store/bots';
 
 export default function CreateBot(props) {
 
     const dispatch = useDispatch();
     useEffect(()=>{
-        dispatch(loadAllBots())
+        dispatch(loadCompleteBots())
     }, [])
 
-    const allBots = useSelector(state => state.bots.explore) || [];
+    const allBots = useSelector(state => state.bots.completeBots) || [];
     let newId = null;
     console.log(allBots);
     let maxId = -1;
     for (let i=0; i<allBots.length; i++){
         if (maxId <= allBots[i].id) maxId = allBots[i].id + 1
     }
-    newId = maxId
+    newId = maxId + 1
     console.log(newId);
 
     if (newId > -1) props.history.push(`/edit-bot/${newId}`);

--- a/client/src/store/bots.js
+++ b/client/src/store/bots.js
@@ -1,4 +1,4 @@
-import { SET_BOT, SET_BOTS, SET_ALL, SET_ONE } from '../constants';
+import { SET_BOT, SET_BOTS, SET_ALL, SET_ONE, SET_COMPLETE } from '../constants';
 
 const setBot = bot => ({
   type: SET_BOT,
@@ -12,6 +12,10 @@ export const setOne = bot => ({
   type: SET_ONE,
   bot,
 });
+export const setComplete = completeBots => ({
+  type: SET_COMPLETE,
+  completeBots
+})
 
 export const loadAllBots = () => async dispatch => {
   try {
@@ -24,6 +28,19 @@ export const loadAllBots = () => async dispatch => {
     console.error(e)
   }
 }
+
+export const loadCompleteBots = () => async dispatch => {
+  try {
+    const res = await fetch('/api/bots/complete')
+    if(res.ok) {
+      const bots = await res.json();
+      dispatch(setComplete(bots.data));
+    }
+  } catch(e) {
+    console.error(e)
+  }
+}
+
 export const loadOne = (id) => async dispatch => {
   try {
     const res = await fetch(`/api/bots/detail/${id}`)
@@ -88,6 +105,8 @@ export default function botReducer (state={ bot: { name: "", rules: [] } }, acti
             return { ...state, explore: action.bots };
         case SET_ONE:
             return { ...state, one: action.bot };
+          case SET_COMPLETE:
+            return { ...state, completeBots: action.completeBots };
         default:
             return state;
         }


### PR DESCRIPTION
The id generation on the "create a bot" button now takes into account drafts as well as published bots and will no longer sometimes take you to a form that has information pre-filled.