### PR TITLE
fix incorrect id picking

### DIFF
--- a/client/src/pages/CreateBot.js
+++ b/client/src/pages/CreateBot.js
@@ -9,7 +9,10 @@ export default function CreateBot(props) {
         dispatch(loadCompleteBots())
     }, [])
 
-    const allBots = useSelector(state => state.bots.completeBots) || [];
+    const allBots = useSelector(state => state.bots.completeBots) || null;
+    if (allBots === null) {
+        return <h1>Loading...</h1>;
+    }
     let newId = null;
     console.log(allBots);
     let maxId = -1;


### PR DESCRIPTION
The "create a bot" button will now no longer pick an id of "0" some percentage of the time.